### PR TITLE
Adding 'required' toggle to variable metadata fields

### DIFF
--- a/metadata_form/Home.py
+++ b/metadata_form/Home.py
@@ -129,11 +129,17 @@ if uploaded_file is not None:
         column_submitted = st.form_submit_button("Submit")
 
     if column_submitted or ("output_yaml" in st.session_state and st.session_state["output_yaml"]):
+        required_var_fields = [
+            key
+            for key, value in constants.DATA_VARIABLE_ERDDAP_FIELDS.items()
+            if value["required"] is True
+        ]
+
         all_valid = True
         for key, value in column_metadata.items():
             validation_result, missing_key = validate_metadata_dict(
                 metadata=value,
-                required_keys=constants.DATA_VARIABLE_ERDDAP_FIELDS,
+                required_keys=required_var_fields,
             )
             if not validation_result:
                 st.error(

--- a/metadata_form/data/constants.py
+++ b/metadata_form/data/constants.py
@@ -69,13 +69,28 @@ GLOBAL_ERDDAP_FIELDS = {
 }
 
 
-DATA_VARIABLE_ERDDAP_FIELDS = [
-    "destinationName",
-    "ioos_category",
-    "long_name",
-    "standard_name",
-    "units",
-]
+DATA_VARIABLE_ERDDAP_FIELDS = {
+    "destinationName": {
+        "description": "Name of the variable in the destination ERDDAP server",
+        "required": True,
+    },
+    "ioos_category": {
+        "description": "Category of the variable according to IOOS standards",
+        "required": True,
+    },
+    "long_name": {
+        "description": "Long descriptive name of the variable",
+        "required": True,
+    },
+    "standard_name": {
+        "description": "Standardized name following a specific vocabulary",
+        "required": False,
+    },
+    "units": {
+        "description": "Units of measurement for the variable values",
+        "required": False,
+    },
+}
 
 IOOS_CATEGORIES = [
     "Bathymetry",


### PR DESCRIPTION
This adds an additional field to the variable-level metadata input form, which can be used to toggle which fields are required. This mirrors the approach used for the global metadata fields. 