### PR TITLE
Adding serverAddress argument to Launch Command

### DIFF
--- a/metadata_form/Dockerfile
+++ b/metadata_form/Dockerfile
@@ -18,4 +18,4 @@ EXPOSE 8501
 
 HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 
-ENTRYPOINT ["streamlit", "run", "metadata_form/Home.py", "--server.port=8501", "--server.address=0.0.0.0"]
+ENTRYPOINT ["streamlit", "run", "metadata_form/Home.py", "--server.port=8501", "--server.address=0.0.0.0", "--browser.serverAddress=mbon.metadata.neracoos.org"]


### PR DESCRIPTION
After deploying the scale-to-zero inrastructure, the Streamlit app at `mbon.metadata.neracoos.org` loads, but hangs indefinitely:

<img width="1227" alt="Screenshot 2024-07-25 at 2 39 36 PM" src="https://github.com/user-attachments/assets/6ec69b0d-0db3-4a50-a903-12ca2fdffc86">

This PR adds the destination URL to the launch args, to address a potential CORS issue as referenced here: https://docs.streamlit.io/knowledge-base/deploy/remote-start#symptom-2-the-app-says-please-wait-or-shows-skeleton-elements-forever