### PR TITLE
Disabling websockets in Streamlit options

### DIFF
--- a/metadata_form/Dockerfile
+++ b/metadata_form/Dockerfile
@@ -18,4 +18,12 @@ EXPOSE 8501
 
 HEALTHCHECK CMD curl --fail http://localhost:8501/_stcore/health
 
-ENTRYPOINT ["streamlit", "run", "metadata_form/Home.py", "--server.port=8501", "--server.address=0.0.0.0", "--browser.serverAddress=mbon.metadata.neracoos.org"]
+ENTRYPOINT [\
+    "streamlit", \
+    "run", \
+    "metadata_form/Home.py", \
+    "--server.port=8501", \
+    "--server.address=0.0.0.0", \
+    "--browser.serverAddress=mbon.metadata.neracoos.org", \
+    "--server.enableWebsocketCompression=false" \
+    ]


### PR DESCRIPTION
Websocket connections are not currently supported by the KEDA http-scaler (https://github.com/kedacore/http-add-on/issues/654), so this PR disables them for the metadata form. 

Related discussion here: https://github.com/gulfofmaine/neracoos-aws-cd/pull/229